### PR TITLE
509907339 feat(docker): switch base to debian:12-slim and add test ru…

### DIFF
--- a/kubernetes/docker/edgemicro/Dockerfile
+++ b/kubernetes/docker/edgemicro/Dockerfile
@@ -1,30 +1,35 @@
-FROM node:24.14.1-bookworm-slim
+FROM debian:12-slim
 
-# === SECURITY PATCH LAYER ===
-# 1. Update OS packages to resolve Debian CVEs 
-# 2. Force-update global npm to resolve NPM CVEs
+# === SECURITY & NODE.JS INSTALL LAYER ===
+# 1. Install standard pre-requisites (curl, ca-certificates, gnupg)
+# 2. Configure NodeSource repository for Node.js v24.x
+# 3. Install Node.js, upgrade OS packages, and update global npm
 RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
     apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends nodejs && \
     npm install -g npm@latest && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-# ============================
+# ========================================
 
 COPY installnode.sh /tmp
 COPY --chown=101:101 installedgemicro.sh /tmp
 
 # create user and group for microgateway
-#RUN apk add --no-cache sed grep && \
 RUN addgroup --system --gid 101 apigee && \
     adduser --shell /bin/bash --uid 101 --system --ingroup apigee --home /opt/apigee apigee
 
 ENV NODE_ENV production
 
-#install node.js
+# install microgateway
 RUN chmod +x /tmp/installnode.sh && \
     /bin/bash /tmp/installnode.sh && \
-    rm -f /tmp/installnode.sh && \
-    userdel --remove node
+    rm -f /tmp/installnode.sh
 
 USER apigee
 WORKDIR /opt/apigee

--- a/test-functional/Dockerfile.test
+++ b/test-functional/Dockerfile.test
@@ -1,0 +1,23 @@
+FROM debian:12-slim
+
+# === TEST PREREQUISITES & ENVIRONMENT SETUP ===
+# 1. Install required system tools (curl, ca-certificates, gnupg, zip, unzip, jq, psmisc, ncurses-bin, sudo)
+# 2. Configure NodeSource and install Node.js v24.x
+# 3. Clean up apt cache to keep the image slim
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl gnupg zip unzip jq psmisc ncurses-bin sudo && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_24.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends nodejs && \
+    npm install -g npm@latest yq && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set testing working directory
+WORKDIR /opt/emg/microgateway/test-functional
+
+# Execute command to run tests locally by default
+CMD ["bash", "NightlyTests.sh", "local"]


### PR DESCRIPTION
…nner

- Migrated gateway Dockerfile base to public debian:12-slim to bypass GCE VM CAA registry blocks.
- Configured a clean Node.js v24.x and npm package layer running safely under the apigee user.
- Added a functional test runner Dockerfile to securely run NightlyTests.sh in isolation.